### PR TITLE
Add and edit workout modal are now closable via the native android ba…

### DIFF
--- a/screens/WorkoutDetails.tsx
+++ b/screens/WorkoutDetails.tsx
@@ -845,7 +845,7 @@ export default function WorkoutDetails() {
         </TouchableWithoutFeedback>
       </Modal>
 
-      <Modal visible={showExerciseModal} animationType="fade" transparent>
+      <Modal visible={showExerciseModal} animationType="fade" transparent onRequestClose={closeAddExerciseModal}>
         {showExerciseModal && (
           <StatusBar
             backgroundColor={theme.type === 'light' ? "rgba(0, 0, 0, 0.5)" : "black"}
@@ -939,7 +939,7 @@ export default function WorkoutDetails() {
         </TouchableWithoutFeedback>
       </Modal>
 
-      <Modal visible={showWebLinkModal} animationType="fade" transparent>
+      <Modal visible={showWebLinkModal} animationType="fade" transparent onRequestClose={closeWebLinkModal}>
         {showWebLinkModal && (
           <StatusBar
             backgroundColor={theme.type === 'light' ? "rgba(0, 0, 0, 0.5)" : "black"}


### PR DESCRIPTION
Hi, 
me again! This time, I only have a little quality of life update. As I was adding and editing my exercises, I have seen that you cannot close them with the native android back button. Therefore, I added the onRequestClose callback (https://reactnative.dev/docs/modal#onrequestclose), with the behavior, that it just closes the modal as the respective "close" buttons on them.

Hopefully, this change is okay for you!

Best regards,
Sha4dow :)